### PR TITLE
Branch 1.12.1

### DIFF
--- a/kubeha-gen.sh
+++ b/kubeha-gen.sh
@@ -237,7 +237,8 @@ for index in 1 2; do
 done
 
 kubectl apply -f https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.12.1/calico/rbac.yaml
-curl -fsSL https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.12.1/calico/calico.yaml | sed "s/10.244.0.0/${CIDR}/g" | kubectl apply -f -
+curl -fsSL https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.12.1/calico/calico.yaml | sed "s!10.244.0.0/16!${CIDR}!g" | kubectl apply -f -
+
 
 echo "Cluster create finished."
 

--- a/kubesi-gen.sh
+++ b/kubesi-gen.sh
@@ -6,7 +6,8 @@ rm -f $HOME/.kube/config
 cp -f /etc/kubernetes/admin.conf ${HOME}/.kube/config
 
 kubectl apply -f https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.11.0/calico/rbac.yaml
-curl -fsSL https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.12.1/calico/calico.yaml | sed "s/10.244.0.0/${CIDR}/g" | kubectl apply -f -
+curl -fsSL https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.12.1/calico/calico.yaml | sed "s!10.244.0.0/16!${CIDR}!g" | kubectl apply -f -
+
 echo "Cluster create finished."
 
 mkdir -p ~/ikube/tls


### PR DESCRIPTION
# What dose this PR do?

Fix sed error in calico-node deploy command
```shell
$ curl -fsSL https://raw.githubusercontent.com/Lentil1016/kubeadm-ha/1.12.1/calico/calico.yaml | sed s/10.244.0.0/10.244.0.0/16/g | kubectl apply -f -
sed：-e 表达式 #1，字符 27：“s”的未知选项
error: no objects passed to apply
curl: (23) Failed writing body (2179 != 2759)
```