### PR TITLE
fix: #12

### DIFF
--- a/kubeha-gen.sh
+++ b/kubeha-gen.sh
@@ -150,6 +150,9 @@ ${HEALTH_CHECK}
   ETCD_MEMBER="${ETCD_MEMBER}${host}=https://${ip}:2380"
 
   echo """
+kind: InitConfiguration
+apiVersion: kubeadm.k8s.io/v1alpha3
+---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration
 kubernetesVersion: v1.12.1

--- a/kubeha-upgrade.sh
+++ b/kubeha-upgrade.sh
@@ -148,6 +148,9 @@ ${HEALTH_CHECK}
   ETCD_MEMBER="${ETCD_MEMBER}${host}=https://${ip}:2380"
 
   echo """
+kind: InitConfiguration
+apiVersion: kubeadm.k8s.io/v1alpha3
+---
 apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 kubernetesVersion: v1.11.0


### PR DESCRIPTION
Fix #12 by adding `InitConfiguration` to `kubeadm-config.yaml` as a workaround. This to avoid the error when running `kubeadm alpha phase kubelet write-env-file` command.

```
didn't recognize types with GroupVersionKind: [kubeadm.k8s.io/v1alpha3, Kind=ClusterConfiguration]
```

This is a `kubeadm` bug. And will probably be fixed in 1.14.0